### PR TITLE
Add skipPOMs parameter to skip POM projects

### DIFF
--- a/src/it/rpm-skip-poms/pom.xml
+++ b/src/it/rpm-skip-poms/pom.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd ">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.rpm.its</groupId>
+  <artifactId>rpm-skip-poms</artifactId>
+  <version>1.0</version>
+  <packaging>pom</packaging>
+
+  <inceptionYear>2016</inceptionYear>
+  <organization>
+    <name>Example, Inc.</name>
+    <url>www.example.org</url>
+  </organization>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-source-plugin</artifactId>
+        <version>2.1.2</version>
+        <executions>
+          <execution>
+            <id>attach-sources</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>attached-rpm</goal>
+            </goals>
+            <configuration>
+              <skipPOMs>true</skipPOMs>
+              <distribution>My App</distribution>
+              <group>Application/Collectors</group>
+              <needarch>false</needarch>
+              <defaultUsername>myuser</defaultUsername>
+              <defaultGroupname>mygroup</defaultGroupname>
+              <mappings>
+                <mapping>
+                  <directory>/usr/myusr/app/lib</directory>
+                  <directoryIncluded>false</directoryIncluded>
+                  <artifact />
+                </mapping>
+                <mapping>
+                  <directory>/usr/myusr/app/sources</directory>
+                  <directoryIncluded>false</directoryIncluded>
+                  <artifact>
+                    <classifiers>
+                      <classifier>sources</classifier>
+                    </classifiers>
+                  </artifact>
+                </mapping>
+              </mappings>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/rpm-skip-poms/src/main/java/org/codehaus/mojo/rpm/it/module/jar/TestClass.java
+++ b/src/it/rpm-skip-poms/src/main/java/org/codehaus/mojo/rpm/it/module/jar/TestClass.java
@@ -1,0 +1,9 @@
+package org.codehaus.mojo.rpm.it.module.jar;
+
+public final class TestClass
+{
+    public TestClass()
+    {
+        System.out.println("some message");
+    }
+}

--- a/src/it/rpm-skip-poms/verify.groovy
+++ b/src/it/rpm-skip-poms/verify.groovy
@@ -1,0 +1,6 @@
+File rpm = new File(localRepositoryPath, "org/codehaus/mojo/rpm/its/rpm-skip-poms/1.0/rpm-skip-poms-1.0.rpm")
+
+if (rpm.exists())
+    throw new java.lang.AssertionError("${rpm.getAbsolutePath()} should not exist");
+
+return true

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -611,6 +611,14 @@ abstract class AbstractRPMMojo
     @Parameter( defaultValue = "${settings}", readonly = true )
     private Settings settings;
 
+    /**
+     * Indicates if the execution should be disabled for POM projects. If <code>true</code>, nothing will happen during
+     * execution in projects with packaging "pom".
+     * @since 2.1.6
+     */
+    @Parameter(defaultValue = "false")
+    private boolean skipPOMs;
+
     //////////////////////////////////////////////////////////////////////////
 
     /**
@@ -661,6 +669,12 @@ abstract class AbstractRPMMojo
     public final void execute()
         throws MojoExecutionException, MojoFailureException
     {
+        if ( skipPOMs && isPOM() )
+        {
+            getLog().info("skipping because artifact is a pom (skipPOMs)");
+            return;
+        }
+
         if ( disabled )
         {
             getLog().info( "MOJO is disabled. Doing nothing." );
@@ -717,6 +731,24 @@ abstract class AbstractRPMMojo
         if ( this.copyTo != null ) {
         	makeSecondCopy();
         }
+    }
+
+    /**
+     * @return The Maven project used by this MOJO
+     */
+    private MavenProject getProject() {
+        if (project.getExecutionProject() != null) {
+            return project.getExecutionProject();
+        }
+
+        return project;
+    }
+
+    /**
+     * @return Whether the artifact is a POM or not
+     */
+    private boolean isPOM() {
+        return "pom".equalsIgnoreCase(getProject().getArtifact().getType());
     }
 
     private void makeSecondCopy() throws MojoFailureException {


### PR DESCRIPTION
Maven projects with packaging "pom" do not produce an executable artifact and should be skipped.

This simplifies using the rpm-maven-plugin in multi-module builds in which the configuration of the plugin is done in the parent project (usually just a POM with the conventions for the sub-modules) and RPMs should be built only in the sub-modules with packaging "jar" (or "war" or similar).