### PR TITLE
allow rpmbuild executable path to be specified by a property

### DIFF
--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -67,6 +67,13 @@ abstract class AbstractRPMMojo
 {
 
     /**
+     * the full path to the rpmbuild executable to use
+     * default to the relative/somewhere on the path 'rpmbuild'
+     */
+    @Parameter( alias = "rpmBuildExe", property = "rpm.rpmbuild.exe", defaultValue = "rpmbuild")
+    private String rpmRpmbuildExe;
+    
+    /**
      * The name portion of the output file name.
      */
     @Parameter( required = true, property = "rpm.name", defaultValue = "${project.artifactId}" )
@@ -1560,6 +1567,22 @@ abstract class AbstractRPMMojo
         return this.defaultFilterWrappers;
     }
 
+    /**
+     * @return the rpmRpmbuildExe
+     */
+    final public String getRpmRpmbuildExe()
+    {
+        return rpmRpmbuildExe;
+    }
+
+    /**
+     * @param rpmRpmbuildExe the rpmRpmbuildExe to set
+     */
+    final public void setRpmRpmbuildExe( String rpmRpmbuildExe )
+    {
+        this.rpmRpmbuildExe = rpmRpmbuildExe;
+    }
+    
     /**
      * Load and decrypt gpg passphrase from maven settings if not given from plugin configuration
      *

--- a/src/main/java/org/codehaus/mojo/rpm/RPMHelper.java
+++ b/src/main/java/org/codehaus/mojo/rpm/RPMHelper.java
@@ -110,7 +110,7 @@ final class RPMHelper
         final File f = new File( workarea, "SPECS" );
 
         final Commandline cl = new Commandline();
-        cl.setExecutable( "rpmbuild" );
+        cl.setExecutable( mojo.getRpmRpmbuildExe() );
         cl.setWorkingDirectory( f.getAbsolutePath() );
         cl.createArg().setValue( "-bb" );
         cl.createArg().setValue( "--target" );


### PR DESCRIPTION
on apple's mac OS X, it appears that the shell is unable to find the rpmbuild on the path.  something about how the /bin/sh is started - it doesn't seem to inherit the user's path configuration.

I am proposing a way to allow one to set a property which can point to the rpmbuild directly/fully.

it has multiple benefits:

a) to allow this plugin to be used on OS X
b) allow one to point directly at the particular version of rpmbuild that is required to be used (should there be multiple versions of rpmbuild available).

