### PR TITLE
Allow for scriptlets and triggers to be filtered with properties.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ target
 .classpath
 .project
 *.iml
+.idea
+.vagrant

--- a/src/it/rpm-filter-scriptlet/pom.xml
+++ b/src/it/rpm-filter-scriptlet/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.rpm.its</groupId>
+  <artifactId>rpm-filter-scriptlet</artifactId>
+  <version>1.0</version>
+  <packaging>jar</packaging>
+
+  <inceptionYear>2016</inceptionYear>
+  <organization>
+    <name>Example, Inc.</name>
+    <url>www.example.org</url>
+  </organization>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>rpm</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <group>Application/Collectors</group>
+          <preinstallScriptlet>
+            <script>echo "installing ${project.artifactId}"</script>
+          </preinstallScriptlet>
+          <postinstallScriptlet>
+            <scriptFile>src/main/scripts/postinstall.sh</scriptFile>
+            <fileEncoding>utf-8</fileEncoding>
+            <filter>true</filter>
+          </postinstallScriptlet>
+          <triggers>
+            <installTrigger>
+              <script>echo "a filtered install trigger for ${project.artifactId}"</script>
+              <triggers>
+                <trigger>dependency</trigger>
+                <trigger>dependency1</trigger>
+              </triggers>
+            </installTrigger>
+          </triggers>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/rpm-filter-scriptlet/src/main/scripts/postinstall.sh
+++ b/src/it/rpm-filter-scriptlet/src/main/scripts/postinstall.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+PROJECT_NAME=${project.artifactId}

--- a/src/it/rpm-filter-scriptlet/verify.groovy
+++ b/src/it/rpm-filter-scriptlet/verify.groovy
@@ -1,0 +1,12 @@
+File specFile = new File( basedir, "target/rpm/rpm-filter-scriptlet/SPECS/rpm-filter-scriptlet.spec" )
+
+// Test if the pre install inline <script> was filtered
+assert specFile.text.contains("echo \"installing rpm-filter-scriptlet\"")
+
+// Test if the post install <scriptFile> was filtered
+assert specFile.text.contains("PROJECT_NAME=rpm-filter-scriptlet")
+
+// Test if the trigger script was filtered
+assert specFile.text.contains("echo \"a filtered install trigger for rpm-filter-scriptlet\"")
+
+return true

--- a/src/main/java/org/codehaus/mojo/rpm/BaseTrigger.java
+++ b/src/main/java/org/codehaus/mojo/rpm/BaseTrigger.java
@@ -19,6 +19,8 @@ package org.codehaus.mojo.rpm;
  * under the License.
  */
 
+import org.apache.maven.shared.utils.io.FileUtils;
+
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.List;
@@ -91,12 +93,13 @@ public abstract class BaseTrigger
      * Writes the complete trigger directive. Use instead of {@link #write(PrintWriter, String)}.
      *
      * @param writer {@code PrintWriter} to write the trigger directive to.
+     * @param filterWrappers The filter wrappers to be applied when writing the content.
      * @throws IOException
      */
-    protected void writeTrigger( PrintWriter writer )
+    protected void writeTrigger( PrintWriter writer, final List<FileUtils.FilterWrapper> filterWrappers )
         throws IOException
     {
-        write( writer, getDirective() );
+        write( writer, getDirective(), filterWrappers );
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
+++ b/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
@@ -262,27 +262,24 @@ public class Scriptlet
      * @param filterWrappers The filter wrappers to be applied when writing the content.
      * @throws IOException
      */
-    protected final void writeContent( PrintWriter writer, final List<FileUtils.FilterWrapper> filterWrappers)
+    protected final void writeContent( PrintWriter writer, final List<FileUtils.FilterWrapper> filterWrappers )
         throws IOException
     {
-        Reader reader = null;
         if ( script != null )
         {
-            reader = new StringReader(script);
+            writer.println( script );
         }
         else if ( scriptFile.exists() )
         {
-            reader = fileEncoding != null ? new InputStreamReader( new FileInputStream( scriptFile ), fileEncoding )
+            Reader reader =
+                    fileEncoding != null ? new InputStreamReader( new FileInputStream( scriptFile ), fileEncoding )
                             : new FileReader( scriptFile );
-        }
-        if(reader != null) {
-            if(filter) {
-                for ( FileUtils.FilterWrapper wrapper : filterWrappers )
-                {
-                    reader = wrapper.getReader( reader );
+            if(filter)
+            {
+                for ( FileUtils.FilterWrapper filterWrapper : filterWrappers ) {
+                    reader = filterWrapper.getReader( reader );
                 }
             }
-
             BufferedReader bufferedReader = null;
             try
             {
@@ -316,7 +313,6 @@ public class Scriptlet
                 }
             }
         }
-
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
@@ -19,9 +19,7 @@ package org.codehaus.mojo.rpm;
  * under the License.
  */
 
-import java.io.File;
-import java.io.IOException;
-import java.io.PrintWriter;
+import java.io.*;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -129,7 +127,8 @@ final class SpecWriter
         if ( mojo.getInstallScriptlet() != null )
         {
             spec.println();
-            mojo.getInstallScriptlet().writeContent( spec );
+            mojo.getInstallScriptlet().writeContent( spec , mojo.getFilterWrappers());
+
         }
 
         writeFiles();
@@ -140,7 +139,7 @@ final class SpecWriter
         {
             for ( BaseTrigger trigger : mojo.getTriggers() )
             {
-                trigger.writeTrigger( spec );
+                trigger.writeTrigger( spec, mojo.getFilterWrappers() );
             }
         }
 
@@ -565,7 +564,7 @@ final class SpecWriter
         {
             if ( scriptlets[i] != null )
             {
-                scriptlets[i].write( spec, directives[i] );
+                scriptlets[i].write( spec, directives[i], mojo.getFilterWrappers() );
             }
         }
     }

--- a/src/site/apt/adv-params.apt
+++ b/src/site/apt/adv-params.apt
@@ -71,16 +71,21 @@ Advanced Parameters
   Maximum RPM since the operation of the scripts must be done correctly or
   major problems can occur while installing or removing the package.
 
+  Script files can be filtered by setting <<<<filter>>>> to true while inline
+  scripts can be filtered together with the pom.
+
   Here are examples of passing the content of the script in the pom
-  (using <<<<script>>>>) and in a file (using <<<<scriptFile>>>>):
+  (using <<<<script>>>>) and in a file (using <<<<scriptFile>>>>) and enabling
+  filtering for preinstall.sh script:
 
 +-----+
 <prepareScriptlet>
-  <script>echo "prepare"</script>
+  <script>echo "preparing ${project.name}"</script>
 </prepareScriptlet>
 <preinstallScriptlet>
   <scriptFile>/src/main/bin/preinstall.sh</scriptFile>
   <fileEncoding>utf-8</fileEncoding>
+  <filter>true</filter>
 </preinstallScriptlet>
 +-----+
 

--- a/src/site/apt/example1.apt.vm
+++ b/src/site/apt/example1.apt.vm
@@ -153,16 +153,17 @@ Sample Configuration
             </mapping>
           </mappings>
           <preinstallScriptlet>
-            <script>echo "installing now"</script>
+            <script>echo "installing \${project.name} now"</script>
           </preinstallScriptlet>
           <postinstallScriptlet>
             <scriptFile>src/main/scripts/postinstall</scriptFile>
             <fileEncoding>utf-8</fileEncoding>
+            <filter>true</filter>
           </postinstallScriptlet>
           <preremoveScriptlet>
             <scriptFile>src/main/scripts/preremove</scriptFile>
             <fileEncoding>utf-8</fileEncoding>
-          </preremoveScript>
+          </preremoveScriptlet>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
A new configuration property "filter" were added for scriptlets and
triggers.  The underlying implementation uses the default filter wrappers
available in the RPM mojo.

Both script or scriptFile can be filtered with standard maven filtering by setting the "filter" parameter to true:
```
                    <preinstallScriptlet>
                        <scriptFile>rpm/preInstall.sh</scriptFile>
                        <filter>true</filter>
                    </preinstallScriptlet>
```