### PR TITLE
Add support for scriptlet dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 target
 .settings
 .classpath

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -276,6 +276,27 @@ abstract class AbstractRPMMojo
     private LinkedHashSet<String> requires;
 
     /**
+     * The list of requirements for running the pre-installation scriptlet.
+     * @since 2.1.6
+     */
+    @Parameter
+    private LinkedHashSet<String> requiresPre;
+
+    /**
+     * The list of requirements for running the post install scriptlet.
+     * @since 2.1.6
+     */
+    @Parameter
+    private LinkedHashSet<String> requiresPost;
+
+    /**
+     * The list of requirements for running the pre-removal scriptlet.
+     * @since 2.1.6
+     */
+    @Parameter
+    private LinkedHashSet<String> requiresPreun;
+
+    /**
      * The list of prerequisites for this package.
      *
      * @since 2.0-beta-3
@@ -1280,6 +1301,30 @@ abstract class AbstractRPMMojo
     final LinkedHashSet<String> getRequires()
     {
         return this.requires;
+    }
+
+    /**
+     * @return Returns the {@link #requiresPre}.
+     */
+    final LinkedHashSet<String> getRequiresPre()
+    {
+        return this.requiresPre;
+    }
+
+    /**
+     * @return Returns the {@link #requiresPreun}.
+     */
+    final LinkedHashSet<String> getRequiresPreun()
+    {
+        return this.requiresPreun;
+    }
+
+    /**
+     * @return Returns the {@link #requiresPost}.
+     */
+    final LinkedHashSet<String> getRequiresPost()
+    {
+        return this.requiresPost;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
@@ -92,6 +92,9 @@ final class SpecWriter
 
         writeList( mojo.getProvides(), "Provides: " );
         writeList( mojo.getRequires(), "Requires: " );
+        writeList( mojo.getRequiresPre(), "Requires(pre): " );
+        writeList( mojo.getRequiresPost(), "Requires(post): " );
+        writeList( mojo.getRequiresPreun(), "Requires(preun): " );
         writeList( mojo.getPrereqs(), "PreReq: " );
         writeList( mojo.getObsoletes(), "Obsoletes: " );
         writeList( mojo.getConflicts(), "Conflicts: " );

--- a/src/site/apt/adv-params.apt
+++ b/src/site/apt/adv-params.apt
@@ -18,7 +18,7 @@ Advanced Parameters
   <<These parameters relate to the dependencies between RPM packages, not to
   the dependencies required to build the RPM package contents.>>
 
-  There are three RPM spec file tags related to dependency management:
+  There are six RPM spec file tags related to dependency management:
 
     * <<<provides>>> defines a <virtual package> which is provided
       by the package being built
@@ -26,10 +26,26 @@ Advanced Parameters
     * <<<requires>>> identifies a package that is required to be installed for
       the package being built to operate correctly
 
+    * <<<requiresPre>>> identifies a package that is required to be installed for
+      the pre-installation scriptlet of the package being built to operate correctly.
+      Packages that are listed here are installed before the pre-installation scriptlet
+      of the package being built is run.
+      Corresponds to the <<<Requires(pre)>>> tag in the spec file.
+
+    * <<<requiresPost>>> identifies a package that is required to be installed for
+      the post-installation scriptlet of the package being built to operate correctly.
+      Packages that are listed here are installed before the post-installation scriptlet
+      of the package being built is run.
+      Corresponds to the <<<Requires(post)>>> tag in the spec file.
+
+    * <<<requiresPreun>>> identifies a package that is required to be installed for
+      the pre-removal scriptlet of the package being built to operate correctly.
+      Corresponds to the <<<Requires(preun)>>> tag in the spec file.
+
     * <<<conflicts>>> identifies a package which must not be installed if the
       package being built is installed
 
-  All three of these tags can appear multiple times in the spec file.  To
+  All of these tags can appear multiple times in the spec file.  To
   configure these tags in the plugin configuration, specify an element for
   each instance of the tag in the spec file; the content of the element is the
   exact text to be placed in the spec file.  Please be careful to ensure that
@@ -43,6 +59,18 @@ Advanced Parameters
 <requires>
   <require>trash-truck &gt; 1.0</require>
 </requires>
+<requires>
+  <require>road</require>
+</requires>
+<requiresPre>
+  <require>excavator</require>
+</requiresPre>
+<requiresPost>
+  <require>bulldozer</require>
+</requiresPost>
+<requiresPreun>
+  <require>environment-util = 2.0</require>
+</requiresPreun>
 <conflicts>
   <conflict>incinerator</conflict>
 </conflicts>


### PR DESCRIPTION
You can now add dependencies for the following scriptlets:
- pre
- preun
- post

These are configured like so:

```
<configuration>
    <requiresPre><require>apache</require></requiresPre>
    <requiresPost><require>shadow-util</require></requiresPost>
    <requiresPreun><require>find</require></requiresPreun>
</configuration>
```
