### PR TITLE
Add support for the spec BuildRequires list of dependencies

### DIFF
--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -276,6 +276,12 @@ abstract class AbstractRPMMojo
     private LinkedHashSet<String> requires;
 
     /**
+     * The list of build requirements for this package.
+     */
+    @Parameter
+    private LinkedHashSet<String> buildRequires;
+
+    /**
      * The list of prerequisites for this package.
      *
      * @since 2.0-beta-3
@@ -1280,6 +1286,14 @@ abstract class AbstractRPMMojo
     final LinkedHashSet<String> getRequires()
     {
         return this.requires;
+    }
+
+    /**
+     * @return Returns the {@link #buildRequires}.
+     */
+    final LinkedHashSet<String> getBuildRequires()
+    {
+        return this.buildRequires;
     }
 
     /**

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -277,6 +277,7 @@ abstract class AbstractRPMMojo
 
     /**
      * The list of build requirements for this package.
+     * @since 2.1.6
      */
     @Parameter
     private LinkedHashSet<String> buildRequires;

--- a/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
@@ -92,6 +92,7 @@ final class SpecWriter
 
         writeList( mojo.getProvides(), "Provides: " );
         writeList( mojo.getRequires(), "Requires: " );
+        writeList( mojo.getBuildRequires(), "BuildRequires: " );
         writeList( mojo.getPrereqs(), "PreReq: " );
         writeList( mojo.getObsoletes(), "Obsoletes: " );
         writeList( mojo.getConflicts(), "Conflicts: " );

--- a/src/site/apt/adv-params.apt
+++ b/src/site/apt/adv-params.apt
@@ -48,6 +48,30 @@ Advanced Parameters
 </conflicts>
 +-----+
 
+* RPM Build Dependency Management
+
+  <<These parameters relate to the dependencies required to build the RPM package contents.>>
+
+  There is one RPM spec file tag related to build dependency management:
+
+    * <<<buildRequires>>> identifies a package that is required to be installed for
+      the package being built to build correctly; i.e. it provides some tools needed
+      during the building of the package, or some RPM macros that must be present
+      when adding the scriptlets into the RPM package.
+
+  This tag can appear multiple times in the spec file.  To
+  configure this tag in the plugin configuration, specify an element for
+  each instance of the tag in the spec file; the content of the element is the
+  exact text to be placed in the spec file.  Please be careful to ensure that
+  version comparison specifications such as <<< < >>> and <<< > >>> are
+  properly specified in the XML file.  Here is an example:
+
++-----+
+<buildRequires>
+  <buildRequire>ruby &gt; 1.8</buildRequire>
+</buildRequires>
++-----+
+
 * {Relocation}
 
   If you specify the <<<prefix/prefixes>>> parameter to the RPM plugin, you can create


### PR DESCRIPTION
Hi,
We needed to have a build-time dependency on some RPM packages, so added support for the
<buildRequires>
  <buildRequire>our-special-build-tool</buildRequire>
</buildRequires>
configuration, that gets converted into BuildRequires: our-special-build-tool in the spec file.

Hope this is of use!
Kind regards, and thanks for the rpm-maven-plugin!

Matt
