### PR TITLE
Add capability to use a scriptFile located in the classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -220,6 +220,9 @@
                 <maven.unix.debug>true</maven.unix.debug>
                 <gpg.homedir>${project.build.testOutputDirectory}/gnupg</gpg.homedir>
               </properties>
+              <setupIncludes>
+                <setupInclude>sample-lib/pom.xml</setupInclude>
+              </setupIncludes>
               <!-- <pomIncludes> <pomInclude>rpm-sign*/pom.xml</pomInclude> </pomIncludes> -->
               <goals>
                 <goal>clean</goal>

--- a/src/it/rpm-filter-scriptlet/pom.xml
+++ b/src/it/rpm-filter-scriptlet/pom.xml
@@ -40,6 +40,10 @@
             <fileEncoding>utf-8</fileEncoding>
             <filter>true</filter>
           </postinstallScriptlet>
+          <preremoveScriptlet>
+            <scriptFile>classpath:preremove.sh</scriptFile>
+            <filter>true</filter>
+          </preremoveScriptlet>
           <triggers>
             <installTrigger>
               <script>echo "a filtered install trigger for ${project.artifactId}"</script>
@@ -50,6 +54,13 @@
             </installTrigger>
           </triggers>
         </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>test</groupId>
+            <artifactId>sample-lib</artifactId>
+            <version>1.0</version>
+          </dependency>
+        </dependencies>
       </plugin>
     </plugins>
   </build>

--- a/src/it/rpm-filter-scriptlet/verify.groovy
+++ b/src/it/rpm-filter-scriptlet/verify.groovy
@@ -6,6 +6,9 @@ assert specFile.text.contains("echo \"installing rpm-filter-scriptlet\"")
 // Test if the post install <scriptFile> was filtered
 assert specFile.text.contains("PROJECT_NAME=rpm-filter-scriptlet")
 
+// Test if the pre remove <scriptFile> was filtered
+assert specFile.text.contains("echo \"Erasing version 1.0\"")
+
 // Test if the trigger script was filtered
 assert specFile.text.contains("echo \"a filtered install trigger for rpm-filter-scriptlet\"")
 

--- a/src/it/sample-lib/pom.xml
+++ b/src/it/sample-lib/pom.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>test</groupId>
+    <artifactId>sample-lib</artifactId>
+    <version>1.0</version>
+
+</project>

--- a/src/it/sample-lib/src/main/resources/preremove.sh
+++ b/src/it/sample-lib/src/main/resources/preremove.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "Erasing version ${project.version}"

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -97,7 +97,7 @@ abstract class AbstractRPMMojo
     /**
      * The stage to build. Default to '-bb' but let users specify for instance '-ba' if they want source rpms as well.
      */
-    @Parameter( alias = "rpmbuildStage", property = "rpm.rpmbuild.stage", defaultValue = "-bb")
+    @Parameter( alias = "rpmbuildStage", property = "rpm.rpmbuild.stage", defaultValue = "-bb" )
     private String rpmbuildStage;
 
 
@@ -619,7 +619,7 @@ abstract class AbstractRPMMojo
      * Option to copy the created RPM to another location
      * @since 2.1.
      */
-    @Parameter(property="rpm.copyTo")
+    @Parameter( property = "rpm.copyTo" )
     private File copyTo;
 
     //////////////////////////////////////////////////////////////////////////
@@ -652,7 +652,7 @@ abstract class AbstractRPMMojo
      * execution in projects with packaging "pom".
      * @since 2.1.6
      */
-    @Parameter(defaultValue = "false")
+    @Parameter( defaultValue = "false" )
     private boolean skipPOMs;
 
     //////////////////////////////////////////////////////////////////////////
@@ -707,7 +707,7 @@ abstract class AbstractRPMMojo
     {
         if ( skipPOMs && isPOM() )
         {
-            getLog().info("skipping because artifact is a pom (skipPOMs)");
+            getLog().info( "skipping because artifact is a pom (skipPOMs)" );
             return;
         }
 
@@ -730,7 +730,7 @@ abstract class AbstractRPMMojo
             {
                 this.prefixes = new ArrayList<String>();
             }
-            this.prefixes.add(prefix);
+            this.prefixes.add( prefix );
         }
 
         helper = new RPMHelper( this );
@@ -764,16 +764,19 @@ abstract class AbstractRPMMojo
 
         afterExecution();
 
-        if ( this.copyTo != null ) {
-        	makeSecondCopy();
+        if ( this.copyTo != null )
+        {
+            makeSecondCopy();
         }
     }
 
     /**
      * @return The Maven project used by this MOJO
      */
-    private MavenProject getProject() {
-        if (project.getExecutionProject() != null) {
+    private MavenProject getProject()
+    {
+        if ( project.getExecutionProject() != null )
+        {
             return project.getExecutionProject();
         }
 
@@ -783,18 +786,22 @@ abstract class AbstractRPMMojo
     /**
      * @return Whether the artifact is a POM or not
      */
-    private boolean isPOM() {
-        return "pom".equalsIgnoreCase(getProject().getArtifact().getType());
+    private boolean isPOM()
+    {
+        return "pom".equalsIgnoreCase( getProject().getArtifact().getType() );
     }
 
-    private void makeSecondCopy() throws MojoFailureException {
-    	try {
-    		this.getLog().info( "Copy " + this.getRPMFile() + " to " + copyTo );
-    	    FileUtils.copyFile( this.getRPMFile(), copyTo );
-    	}
-    	catch ( IOException e ) {
-    		throw new MojoFailureException( "Unable to copy file" );
-    	}
+    private void makeSecondCopy() throws MojoFailureException
+    {
+        try
+        {
+            this.getLog().info( "Copy " + this.getRPMFile() + " to " + copyTo );
+            FileUtils.copyFile( this.getRPMFile(), copyTo );
+        }
+        catch ( IOException e )
+        {
+            throw new MojoFailureException( "Unable to copy file" );
+        }
     }
 
     /**
@@ -925,20 +932,22 @@ abstract class AbstractRPMMojo
         Log log = getLog();
 
         // Retrieve any versions set by the VersionMojo
-	if ( versionProperty != null ) {
-	    String projversion = this.project.getProperties().getProperty( versionProperty );
-	    if ( projversion != null )
-		{
-		    this.projversion = projversion;
-		}
-	}
-	if ( releaseProperty != null ) {
-	    String release = this.project.getProperties().getProperty( releaseProperty );
-	    if ( release != null )
-		{
-		    this.release = release;
-		}
-	}
+        if ( versionProperty != null )
+        {
+            String projversion = this.project.getProperties().getProperty( versionProperty );
+            if ( projversion != null )
+            {
+                this.projversion = projversion;
+            }
+        }
+        if ( releaseProperty != null )
+        {
+            String release = this.project.getProperties().getProperty( releaseProperty );
+            if ( release != null )
+            {
+                this.release = release;
+            }
+        }
 
         // calculate versions if neccessary, check for existing maven modifier and split them accordingly
         if ( this.projversion == null || this.release == null || this.projversion.contains( "-" ) )
@@ -1631,15 +1640,15 @@ abstract class AbstractRPMMojo
     /**
      * @return the rpmbuildStage
      */
-    final public String getRpmbuildStage()
+    public final String getRpmbuildStage()
     {
         return rpmbuildStage;
     }
 
     /**
-     * @param rpmRpmbuildStage the rpmRpmbuildStage to set
+     * @param rpmbuildStage the rpmRpmbuildStage to set
      */
-    final public void setRpmbuildStage( String rpmbuildStage )
+    public final void setRpmbuildStage( String rpmbuildStage )
     {
         this.rpmbuildStage = rpmbuildStage;
     }

--- a/src/main/java/org/codehaus/mojo/rpm/AttachedRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AttachedRPMMojo.java
@@ -34,7 +34,8 @@ import org.apache.maven.project.MavenProjectHelper;
  * @author Brett Okken, Cerner Corp.
  * @since 2.0-beta-2
  */
-@Mojo( name = "attached-rpm", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true )
+@Mojo( name = "attached-rpm", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true )
 public class AttachedRPMMojo
     extends AbstractRPMMojo
 {

--- a/src/main/java/org/codehaus/mojo/rpm/Dependency.java
+++ b/src/main/java/org/codehaus/mojo/rpm/Dependency.java
@@ -163,9 +163,9 @@ public class Dependency
 
         for ( String s : in )
         {
-            String[] parts = s.split(":");
+            String[] parts = s.split( ":" );
             // Make sure we have group and artifact
-            if(parts.length == 0)
+            if ( parts.length == 0 )
             {
                 throw new MojoExecutionException( "Include and exclude must include both group and artifact IDs." );
             }
@@ -176,15 +176,15 @@ public class Dependency
             String classifier = "";
             VersionRange vr = null;
 
-            if(parts.length > 2)
+            if ( parts.length > 2 )
             {
                 versionStr = parts[2];
-                if(parts.length > 3)
+                if ( parts.length > 3 )
                 {
                     type = parts[3];
                 }
 
-                if(parts.length > 4)
+                if ( parts.length > 4 )
                 {
                     classifier = parts[4];
                 }

--- a/src/main/java/org/codehaus/mojo/rpm/FileHelper.java
+++ b/src/main/java/org/codehaus/mojo/rpm/FileHelper.java
@@ -549,20 +549,20 @@ final class FileHelper
                         if ( item.getVersionRange().containsVersion( dep.getSelectedVersion() ) )
                         {
                             log.debug( "... Version matches" );
-                            if( item.getType().isEmpty() )
+                            if ( item.getType().isEmpty() )
                             {
                                 log.debug( "... Type is empty" );
                                 return true;
                             }
-                            else if( item.getType().equals( dep.getType() ))
+                            else if ( item.getType().equals( dep.getType() ) )
                             {
                                 log.debug( "... Type matches" );
-                                if( item.getClassifier().isEmpty() )
+                                if ( item.getClassifier().isEmpty() )
                                 {
                                     log.debug( "... Classifier is empty" );
                                     return true;
                                 }
-                                else if( item.getClassifier().equals( dep.getClassifier() ))
+                                else if ( item.getClassifier().equals( dep.getClassifier() ) )
                                 {
                                     log.debug( "... Classifier matches" );
                                     return true;

--- a/src/main/java/org/codehaus/mojo/rpm/LogStreamConsumer.java
+++ b/src/main/java/org/codehaus/mojo/rpm/LogStreamConsumer.java
@@ -92,15 +92,15 @@ final class LogStreamConsumer
             case DEBUG:
                 log.debug( line );
                 break;
-            case INFO:
-                log.info( line );
-                break;
             case WARN:
                 log.warn( line );
                 break;
             case ERROR:
                 log.error( line );
                 break;
+            case INFO:
+            default:
+                log.info( line );
         }
     }
 }

--- a/src/main/java/org/codehaus/mojo/rpm/RPMHelper.java
+++ b/src/main/java/org/codehaus/mojo/rpm/RPMHelper.java
@@ -248,11 +248,15 @@ final class RPMHelper
         try
         {
             if ( mojo.getLog().isDebugEnabled() )
+            {
                 mojo.getLog().debug( "About to execute \'" + cl.toString() + "\'" );
+            }
             final int result = CommandLineUtils.executeCommandLine( cl, stdConsumer, errConsumer );
             if ( result != 0 )
+            {
                 throw new MojoExecutionException( "rpm -E %{_arch} returned: \'" + result + "\' executing \'"
-                    + cl.toString() + "\'" );
+                        + cl.toString() + "\'" );
+            }
         }
         catch ( CommandLineException e )
         {

--- a/src/main/java/org/codehaus/mojo/rpm/RPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/RPMMojo.java
@@ -28,7 +28,8 @@ import org.apache.maven.plugins.annotations.ResolutionScope;
 /**
  * Construct the RPM file.
  */
-@Mojo( name = "rpm", defaultPhase = LifecyclePhase.PACKAGE, requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true )
+@Mojo( name = "rpm", defaultPhase = LifecyclePhase.PACKAGE,
+        requiresDependencyResolution = ResolutionScope.RUNTIME, threadSafe = true )
 public class RPMMojo
     extends AbstractRPMMojo
 {

--- a/src/main/java/org/codehaus/mojo/rpm/RPMUnpackMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/RPMUnpackMojo.java
@@ -1,5 +1,24 @@
 package org.codehaus.mojo.rpm;
 
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import java.io.File;
 
 import org.apache.maven.plugin.AbstractMojo;
@@ -18,7 +37,8 @@ import org.codehaus.plexus.util.cli.shell.Shell;
 /**
  * Unpack a RPM file. Experimental only. Settings may change in next version
  */
-@Mojo( name = "unpack", requiresProject = false, aggregator = true, defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true )
+@Mojo( name = "unpack", requiresProject = false, aggregator = true,
+        defaultPhase = LifecyclePhase.GENERATE_RESOURCES, threadSafe = true )
 public class RPMUnpackMojo
     extends AbstractMojo
 {

--- a/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
+++ b/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
@@ -137,7 +137,7 @@ public class Scriptlet
     }
 
     /**
-     * The contents of the script as a {@code File}. This will be ignored if {@link #getScript()} is populated.
+     * The contents of the script from a file in the project or in the classpath. This will be ignored if {@link #getScript()} is populated.
      *
      * @return Returns the {@link #scriptFile}.
      */
@@ -214,12 +214,6 @@ public class Scriptlet
     protected final void write( final PrintWriter writer, final String directive, final List<FileUtils.FilterWrapper> filterWrappers)
         throws IOException
     {
-        /*if ( scriptFile != null && !scriptFile.exists() )
-        {
-            throw new RuntimeException( "Invalid scriptlet declaration found - defined scriptFile does not exist: "
-                + scriptFile.getPath() );
-        }*/
-
         if ( script != null || scriptFile != null || program != null )
         {
             writer.println();

--- a/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
+++ b/src/main/java/org/codehaus/mojo/rpm/Scriptlet.java
@@ -21,7 +21,17 @@ package org.codehaus.mojo.rpm;
 
 import org.apache.maven.shared.utils.io.FileUtils;
 
-import java.io.*;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.Reader;
+import java.io.UnsupportedEncodingException;
 import java.util.List;
 
 /**
@@ -137,7 +147,8 @@ public class Scriptlet
     }
 
     /**
-     * The contents of the script from a file in the project or in the classpath. This will be ignored if {@link #getScript()} is populated.
+     * The contents of the script from a file in the project or in the classpath. This will be ignored if
+     * {@link #getScript()} is populated.
      *
      * @return Returns the {@link #scriptFile}.
      */
@@ -211,8 +222,8 @@ public class Scriptlet
      * @param filterWrappers The filter wrappers to be applied when writing the content.
      * @throws IOException
      */
-    protected final void write( final PrintWriter writer, final String directive, final List<FileUtils.FilterWrapper> filterWrappers)
-        throws IOException
+    protected final void write( final PrintWriter writer, final String directive,
+                                final List<FileUtils.FilterWrapper> filterWrappers ) throws IOException
     {
         if ( script != null || scriptFile != null || program != null )
         {
@@ -249,20 +260,29 @@ public class Scriptlet
         return builder.toString();
     }
 
-    private Reader getScriptReader(String path) throws FileNotFoundException, UnsupportedEncodingException {
+    private Reader getScriptReader( String path ) throws FileNotFoundException, UnsupportedEncodingException
+    {
         String classpathPrefix = "classpath:";
         Reader reader;
-        if (path.startsWith(classpathPrefix)) {
-            String classpathResource = path.substring(classpathPrefix.length());
-            InputStream inputStream = Thread.currentThread().getContextClassLoader().getResourceAsStream(classpathResource);
-            if (inputStream == null) {
-                throw new RuntimeException("Invalid scriptlet declaration found - defined scriptFile does not exist: " + path);
+        if ( path.startsWith( classpathPrefix ) )
+        {
+            String classpathResource = path.substring( classpathPrefix.length() );
+            InputStream inputStream = Thread.currentThread().getContextClassLoader()
+                    .getResourceAsStream( classpathResource );
+            if ( inputStream == null )
+            {
+                throw new RuntimeException( "Invalid scriptlet declaration found - defined scriptFile does not exist: "
+                        + path );
             }
-            reader = new InputStreamReader(inputStream);
-        } else {
-            File file = new File(path);
-            if (!file.exists()) {
-                throw new RuntimeException("Invalid scriptlet declaration found - defined scriptFile does not exist: " + path);
+            reader = new InputStreamReader( inputStream );
+        }
+        else
+        {
+            File file = new File( path );
+            if ( !file.exists() )
+            {
+                throw new RuntimeException( "Invalid scriptlet declaration found - defined scriptFile does not exist: "
+                        + path );
             }
             reader = fileEncoding != null ? new InputStreamReader( new FileInputStream( file ), fileEncoding )
                     : new FileReader( scriptFile );
@@ -286,10 +306,11 @@ public class Scriptlet
         }
         else if ( scriptFile != null )
         {
-            Reader reader = getScriptReader(scriptFile);
-            if(filter)
+            Reader reader = getScriptReader( scriptFile );
+            if ( filter )
             {
-                for ( FileUtils.FilterWrapper filterWrapper : filterWrappers ) {
+                for ( FileUtils.FilterWrapper filterWrapper : filterWrappers )
+                {
                     reader = filterWrapper.getReader( reader );
                 }
             }

--- a/src/main/java/org/codehaus/mojo/rpm/Source.java
+++ b/src/main/java/org/codehaus/mojo/rpm/Source.java
@@ -19,7 +19,6 @@ package org.codehaus.mojo.rpm;
  * under the License.
  */
 
-import java.io.File;
 import java.util.List;
 import java.util.Locale;
 import java.util.regex.Pattern;
@@ -46,8 +45,8 @@ public class Source
 
     /**
      * Optional destination name for the file identified by {@link #location}.<br/>
-     * <b>NOTE:</b> This is only applicable if the {@link #location} is a {@link File#isFile() file}, not a
-     * {@link File#isDirectory() directory}.
+     * <b>NOTE:</b> This is only applicable if the {@link #location} is a {@link java.io.File#isFile() file}, not a
+     * {@link java.io.File#isDirectory() directory}.
      */
     private String destination;
 
@@ -195,8 +194,8 @@ public class Source
     /**
      * Sets the destination file name.
      * <p>
-     * <b>NOTE:</b> This is only applicable if the {@link #getLocation() location} is a {@link File#isFile() file}, not
-     * a {@link File#isDirectory() directory}.
+     * <b>NOTE:</b> This is only applicable if the {@link #getLocation() location} is a {@link java.io.File#isFile()
+     * file}, not a {@link java.io.File#isDirectory() directory}.
      * </p>
      *
      * @param destination The destination that the {@link #getLocation() location} should be in the final rpm.

--- a/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
@@ -19,7 +19,9 @@ package org.codehaus.mojo.rpm;
  * under the License.
  */
 
-import java.io.*;
+import java.io.File;
+import java.io.IOException;
+import java.io.PrintWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -131,7 +133,7 @@ final class SpecWriter
         if ( mojo.getInstallScriptlet() != null )
         {
             spec.println();
-            mojo.getInstallScriptlet().writeContent( spec , mojo.getFilterWrappers());
+            mojo.getInstallScriptlet().writeContent( spec , mojo.getFilterWrappers() );
 
         }
 
@@ -247,7 +249,8 @@ final class SpecWriter
                 log.debug( "writing attribute string for identified files in directory: " + destination );
 
                 // only list files if requested (directoryIncluded == false) or we have to
-                if ( !( map.isDirectoryIncluded() && scanner.isEverythingIncluded() && links.isEmpty() && !map.isRecurseDirectories()) )
+                if ( !( map.isDirectoryIncluded() && scanner.isEverythingIncluded() && links.isEmpty()
+                        && !map.isRecurseDirectories() ) )
                 {
                     final String[] files = scanner.getIncludedFiles();
 
@@ -265,7 +268,7 @@ final class SpecWriter
                     if ( map.isDirectoryIncluded() )
                     {
                         // write out destination first
-                        spec.print("%dir ");
+                        spec.print( "%dir " );
                         spec.println( baseFileString + "\"" );
                     }
 
@@ -274,9 +277,9 @@ final class SpecWriter
                         // do not write out base file (destination) again
                         if ( dir.length() > 0 )
                         {
-                            spec.print("%dir ");
-                        	spec.print( baseFileString );
-                            spec.println( StringUtils.replace(dir, "\\", "/") + "\"" );
+                            spec.print( "%dir " );
+                            spec.print( baseFileString );
+                            spec.println( StringUtils.replace( dir, "\\", "/" ) + "\"" );
                         }
                     }
                 }
@@ -322,7 +325,8 @@ final class SpecWriter
         {
             spec.println();
 
-            for ( Map.Entry<String, List<SoftlinkSource>> directoryToSourcesEntry : mojo.getLinkTargetToSources().entrySet() )
+            for ( Map.Entry<String, List<SoftlinkSource>> directoryToSourcesEntry
+                    : mojo.getLinkTargetToSources().entrySet() )
             {
                 String directory = directoryToSourcesEntry.getKey();
                 if ( directory.startsWith( "/" ) )

--- a/src/main/java/org/codehaus/mojo/rpm/UnixPrintWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/UnixPrintWriter.java
@@ -26,6 +26,9 @@ import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.io.Writer;
 
+/**
+ * A unix-specific {@code PrintWriter} implementation
+ */
 public class UnixPrintWriter
     extends PrintWriter
 {

--- a/src/site/apt/adv-params.apt
+++ b/src/site/apt/adv-params.apt
@@ -116,7 +116,8 @@ Advanced Parameters
 
   Each of the scripts can be configured as a
   {{{./apidocs/org/codehaus/mojo/rpm/Scriptlet.html}Scriptlet}}, which allows
-  the content of the script to be provided either as a String or File. If
+  the content of the script to be provided either as a String or file located in
+  the project or in the classpath (using the prefix classpath:). If
   both parameters are specified for a script, the external file will be
   ignored.  Before writing scripts for RPM packages, understand the
   {{{http://www.rpm.org/max-rpm/s1-rpm-inside-scripts.html}script docs}} in
@@ -128,7 +129,7 @@ Advanced Parameters
 
   Here are examples of passing the content of the script in the pom
   (using <<<<script>>>>) and in a file (using <<<<scriptFile>>>>) and enabling
-  filtering for preinstall.sh script:
+  filtering for preinstall.sh and classpath:preremove.sh scripts:
 
 +-----+
 <prepareScriptlet>
@@ -139,6 +140,10 @@ Advanced Parameters
   <fileEncoding>utf-8</fileEncoding>
   <filter>true</filter>
 </preinstallScriptlet>
+<preremoveScriptlet>
+  <scriptFile>classpath:preremove.sh</scriptFile>
+  <filter>true</filter>
+</preremoveScriptlet>
 +-----+
 
 ** <<<prepareScriptlet>>>


### PR DESCRIPTION
Currently the scriptFile tag can only accept a file located in the project.  This change allows to specify a scriptFile located in a jar file (maven artifact) using "classpath:" prefix.  One use case I have is I have a bunch of components packaged as an RPM and all of them uses the same set of scriptlets and this feature would make maintaining the scripts easier.