### PR TITLE
Add <dirmode> parameter to <mapping>

### DIFF
--- a/src/it/rpm-dirmode/invoker.properties
+++ b/src/it/rpm-dirmode/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean install

--- a/src/it/rpm-dirmode/pom.xml
+++ b/src/it/rpm-dirmode/pom.xml
@@ -1,0 +1,100 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.codehaus.mojo.rpm.its</groupId>
+  <artifactId>rpm-dirmode</artifactId>
+  <packaging>rpm</packaging>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>rpm-dirmode</name>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <rpm.install.basedir>/opt/dirmode</rpm.install.basedir>
+  </properties>
+
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <group>Applications/Internet</group>
+          <autoRequires>false</autoRequires>
+          <!-- Intentionally weird default modes so that we can tell where they got applied -->
+          <defaultFilemode>333</defaultFilemode>
+          <defaultDirmode>753</defaultDirmode>
+          <defaultUsername>du02</defaultUsername>
+          <defaultGroupname>dg02</defaultGroupname>
+          <mappings>
+            <mapping>
+              <!-- Only create target directory -->
+              <directory>${rpm.install.basedir}</directory>
+              <filemode>664</filemode>
+              <dirmode>775</dirmode>
+              <username>tu01</username>
+              <groupname>tg01</groupname>
+            </mapping>
+            <mapping>
+              <directory>${rpm.install.basedir}/t1</directory>
+              <filemode>770</filemode>
+              <!-- no dirmode specified. Fall back to filemode (backwards compatibility) -->
+              <username>tu01</username>
+              <groupname>tg01</groupname>
+            </mapping>
+            <mapping>
+              <directory>${rpm.install.basedir}/t2</directory>
+              <!-- no mode/ownership specified. Use defaults -->
+            </mapping>
+            <mapping>
+              <!-- Install *contents* of indicated directory to target location -->
+              <directory>${rpm.install.basedir}</directory>
+              <filemode>664</filemode>
+              <dirmode>775</dirmode>
+              <username>tu01</username>
+              <groupname>tg01</groupname>
+              <directoryIncluded>false</directoryIncluded>
+              <recurseDirectories>true</recurseDirectories>
+              <sources>
+                <source>
+                  <location>${project.basedir}/src/main/resources/dirmode</location>
+                </source>
+              </sources>
+            </mapping>
+            <mapping>
+              <!-- Install entire indicated directory to target location -->
+              <directory>/var/opt/dirmode</directory>
+              <filemode>664</filemode>
+              <dirmode>775</dirmode>
+              <username>tu01</username>
+              <groupname>tg01</groupname>
+              <recurseDirectories>true</recurseDirectories>
+              <sources>
+                <source>
+                  <location>${project.basedir}/src/main/resources/dirmode</location>
+                </source>
+              </sources>
+            </mapping>
+            <mapping>
+              <directory>/var/tmp/dirmode</directory>
+              <filemode>664</filemode>
+              <dirmode>775</dirmode>
+              <username>tu01</username>
+              <groupname>tg01</groupname>
+              <sources>
+                <source>
+                  <location>${project.basedir}/src/main/resources/dirmode</location>
+                </source>
+              </sources>
+            </mapping>
+          </mappings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/more_files.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/more_files.txt
@@ -1,0 +1,1 @@
+A second file located on the top level.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/otherdir/other_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/otherdir/other_file.txt
@@ -1,0 +1,1 @@
+This file is located in the other directory.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/another_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/another_file.txt
@@ -1,0 +1,1 @@
+Another file located in a nested directory.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/deep_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/deep_file.txt
@@ -1,0 +1,1 @@
+This file is deeply nested inside sub directories.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/finaldir/last_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/deepdir/finaldir/last_file.txt
@@ -1,0 +1,1 @@
+This is the most deeply nested file.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/sub_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/subdir/sub_file.txt
@@ -1,0 +1,1 @@
+This file is located in the sub directory.

--- a/src/it/rpm-dirmode/src/main/resources/dirmode/top_level.txt
+++ b/src/it/rpm-dirmode/src/main/resources/dirmode/top_level.txt
@@ -1,0 +1,1 @@
+This file is directly in the indicated directory.

--- a/src/it/rpm-dirmode/src/main/resources/ignored_file.txt
+++ b/src/it/rpm-dirmode/src/main/resources/ignored_file.txt
@@ -1,0 +1,1 @@
+This file is not packaged.

--- a/src/it/rpm-dirmode/verify.groovy
+++ b/src/it/rpm-dirmode/verify.groovy
@@ -1,0 +1,60 @@
+File rpm = new File(localRepositoryPath, "org/codehaus/mojo/rpm/its/rpm-dirmode/0.0.1-SNAPSHOT/rpm-dirmode-0.0.1-SNAPSHOT.rpm")
+
+if (!rpm.exists())
+    throw new AssertionError("${rpm.getAbsolutePath()} does not exist");
+
+lines = new File(basedir, "target/rpm/rpm-dirmode/SPECS/rpm-dirmode.spec").readLines()
+[
+        "Name: rpm-dirmode",
+        "Version: 0.0.1"
+].each {
+    if (!lines.contains(it))
+        throw new AssertionError("Spec file missing \"${it}\"")
+}
+
+proc = ["rpm", "-qvlp", rpm.getAbsolutePath()].execute()
+proc.waitFor()
+lines = proc.in.text.readLines()
+
+[
+        // Explicitly specified directory
+        /drwxrwxr-x\s.+tu01\s+tg01\s.*\s\/opt\/dirmode$/,
+        // Files and directories mapped into the directory above via a separate directoryIncluded=false mapping
+        /-rw-rw-r--\s.+tu01\s+tg01\s.*\s\/opt\/dirmode\/top_level.txt$/,
+        /drwxrwxr-x\s.+tu01\s+tg01\s.*\s\/opt\/dirmode\/subdir\/deepdir\/finaldir$/,
+        /-rw-rw-r--\s.+tu01\s+tg01\s.*\s\/opt\/dirmode\/subdir\/deepdir\/finaldir\/last_file.txt$/,
+        // directory mapping without a dirmode (fallback to filemode)
+        /drwxrwx---\s.+tu01\s+tg01\s.*\s\/opt\/dirmode\/t1$/,
+        // directory mapping that uses default ownership/permission
+        /drwxr-x-wx\s.+du02\s+dg02\s.*\s\/opt\/dirmode\/t2$/,
+        // mapping where the directory is included (no separate directory-only mapping)
+        /drwxrwxr-x\s.+tu01\s+tg01\s.*\s\/var\/opt\/dirmode$/,
+        /drwxrwxr-x\s.+tu01\s+tg01\s.*\s\/var\/opt\/dirmode\/subdir\/deepdir\/finaldir$/,
+        /-rw-rw-r--\s.+tu01\s+tg01\s.*\s\/var\/opt\/dirmode\/subdir\/deepdir\/finaldir\/last_file.txt$/,
+        // For this variant, the 'simpleDir' optimization gets applied.
+        // The spec-file only contains a single entry for the top dir (instead of one entry per file/directory).
+        // The directory permissions for that case are NOT CORRECT. Not sure how to fix.
+        /drw-rw-r--\s.+tu01\s+tg01\s.*\s\/var\/tmp\/dirmode$/,
+        /drw-rw-r--\s.+tu01\s+tg01\s.*\s\/var\/tmp\/dirmode\/subdir\/deepdir\/finaldir$/,
+        /-rw-rw-r--\s.+tu01\s+tg01\s.*\s\/var\/tmp\/dirmode\/subdir\/deepdir\/finaldir\/last_file.txt$/
+].each {
+    if (!lines*.matches(it).contains(true))
+        throw new AssertionError("File/dir/link matching ${it.toString()} missing from RPM!")
+}
+
+[
+        // Ensure that we don't have duplicates of the directory that uses default ownership/permission
+        /d.........\s.+tu01\s+tg01\s.*\s\/opt\/dirmode\/t2/,
+
+        // Ensure that we don't have duplicates of certain directories without the executable bit
+        /d..-..-.--\s.+\s\/opt\/dirmode$/,
+        /d..-..-.--\s.+\s\/opt\/dirmode\/subdir\/deepdir\/finaldir$/,
+].each {
+    if (lines*.matches(it).contains(true))
+        throw new AssertionError("File matching ${it.toString()} should NOT be in the RPM!")
+}
+
+if (lines.size() != 38)
+    throw new AssertionError("Expected: 38 file/dir/links but got: ${lines.size()}")
+
+return true

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -61,7 +61,8 @@ import org.sonatype.plexus.components.sec.dispatcher.SecDispatcherException;
  * @author Carlos
  * @author Brett Okken, Cerner Corp.
  */
-abstract class AbstractRPMMojo
+// Needs to be public, otherwise setters, even public ones, are inaccessible in terms of reflection rules.
+public abstract class AbstractRPMMojo
     extends AbstractMojo
     implements RPMVersionableMojo
 {
@@ -1637,7 +1638,7 @@ abstract class AbstractRPMMojo
     }
 
     /**
-     * @param rpmRpmbuildStage the rpmRpmbuildStage to set
+     * @param rpmbuildStage the rpmRpmbuildStage to set
      */
     final public void setRpmbuildStage( String rpmbuildStage )
     {

--- a/src/site/apt/map-params.apt
+++ b/src/site/apt/map-params.apt
@@ -77,6 +77,31 @@ Mapping Parameters
   {{{./rpm-mojo.html#defaultGroupname}defaultGroupname}}, and
   {{{./rpm-mojo.html#defaultDirmode}defaultDirmode}}) will be used.
 
+* {dirmode}
+
+  This is UNIX permissions (file mode) to assign to directories when installed.
+  This value consists of three octal digits representing the access for the
+  owner, the group, and the world.  Each digit represents the access allowed
+  and is the sum of 4 for read, 2 for write, and 1 for execute (in the context of
+  directories, 'execute' allows the user to list the contents of the directory).
+  A common value to use is "755" which provides the owner read/write access and
+  read-only access to everyone else. Everyone is allowed to list the contents
+  of the directory. For more information on this subject,
+  read {{{http://www.tldp.org/LDP/intro-linux/html/sect_03_04.html}File
+  Security}}, section 3.4 of the Introduction to Linux maintained by the
+  Linux Documentation Project. If not specified, filemode, will be used instead.
+
+  This property is useful if you want files and directories included in a single
+  mapping to have different permissions. The canonical example would be files
+  that are readable (644) and directories that have the executable bit set (755).
+  That way, the directories can be listed, but the files remain non-executable.
+
+  If none of the file attributes (dirmode, filemode, username, and groupname) are
+  populated, the defaults ({{{./rpm-mojo.html#defaultFilemode}defaultFileMode}},
+  {{{./rpm-mojo.html#defaultUsername}defaultUsername}},
+  {{{./rpm-mojo.html#defaultGroupname}defaultGroupname}}, and
+  {{{./rpm-mojo.html#defaultDirmode}defaultDirmode}}) will be used.
+
 * {username} (<<recommended>>)
 
   This is the UNIX username to assign to the files when installed.  If the


### PR DESCRIPTION
Adds a new `<dirmode>` setting to `<mapping>` elements that controls the mode of directories created implicitly as part of translating the mapping element into RPM spec file entries. ( `recurseDirectories=true`) 

For many packages, the user wants ordinary files without the executable bit, while creating directories with the executable bit (so that they can be listed/enumerated)

If 'dirmode' is missing, 'filemode' will be used in an effort to maintain backwards compatibility with the original behaviour.
