### PR TITLE
Remove the public modifier that triggers:

### DIFF
--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -1631,7 +1631,7 @@ abstract class AbstractRPMMojo
     /**
      * @return the rpmbuildStage
      */
-    final public String getRpmbuildStage()
+    final String getRpmbuildStage()
     {
         return rpmbuildStage;
     }
@@ -1639,7 +1639,7 @@ abstract class AbstractRPMMojo
     /**
      * @param rpmRpmbuildStage the rpmRpmbuildStage to set
      */
-    final public void setRpmbuildStage( String rpmbuildStage )
+    final void setRpmbuildStage( String rpmbuildStage )
     {
         this.rpmbuildStage = rpmbuildStage;
     }


### PR DESCRIPTION
java.lang.IllegalAccessException: Class org.codehaus.plexus.component.configurator.converters.ComponentValueSetter can not access a member of class org.codehaus.mojo.rpm.AbstractRPMMojo with modifiers "public final"

https://github.com/mojohaus/rpm-maven-plugin/issues/84