### PR TITLE
Added new parameter: hardLinkDependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
+
 jdk:
-  - openjdk6
-  - oraclejdk7
+  - openjdk7 #Travis does not support oraclejdk7 anymore
   - oraclejdk8
 
 # Install the rpmbuild tool we need.

--- a/provision.sh
+++ b/provision.sh
@@ -22,7 +22,7 @@ function install_mvn {
   fi
 }
 
-install java-1.6.0-openjdk-devel
+install java-1.7.0-openjdk-devel
 install rpm-build
 install wget
 install_mvn 2.2.1

--- a/src/it/rpm-dependency-hardlink/invoker.properties
+++ b/src/it/rpm-dependency-hardlink/invoker.properties
@@ -1,0 +1,1 @@
+invoker.goals = clean package

--- a/src/it/rpm-dependency-hardlink/pom.xml
+++ b/src/it/rpm-dependency-hardlink/pom.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>org.codehaus.mojo.rpm.its</groupId>
+  <artifactId>rpm-dependency-hardlink-module-rpm</artifactId>
+  <version>1.0</version>
+  <packaging>rpm</packaging>
+
+  <inceptionYear>2017</inceptionYear>
+  <organization>
+    <name>my org</name>
+    <url>www.my.org</url>
+  </organization>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>log4j</groupId>
+      <artifactId>log4j</artifactId>
+      <version>1.2.14</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>rpm-maven-plugin</artifactId>
+        <version>@pom.version@</version>
+        <extensions>true</extensions>
+        <configuration>
+          <distribution>My App</distribution>
+          <group>Application/Collectors</group>
+          <release>rel</release>
+          <needarch>false</needarch>
+          <defaultUsername>myuser</defaultUsername>
+          <defaultGroupname>mygroup</defaultGroupname>
+          <hardLinkDependencies>true</hardLinkDependencies>
+          <mappings>
+            <mapping>
+              <directory>/usr/myusr/app</directory>
+              <dependency />
+              <directoryIncluded>false</directoryIncluded>
+            </mapping>
+          </mappings>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/src/it/rpm-dependency-hardlink/verify.groovy
+++ b/src/it/rpm-dependency-hardlink/verify.groovy
@@ -1,0 +1,12 @@
+File rpm = new File(basedir, "target/rpm/rpm-dependency-hardlink-module-rpm/RPMS/noarch/rpm-dependency-hardlink-module-rpm-1.0-rel.noarch.rpm")
+if (!rpm.exists())
+    throw new AssertionError("rpm file does not exist: ${rpm.getAbsolutePath()}")
+
+def proc = ["rpm", "-qlp", rpm.getAbsolutePath()].execute()
+proc.waitFor()
+proc.in.text.eachLine {
+    if (!it.equals("/usr/myusr/app/log4j-1.2.14.jar"))
+        throw new AssertionError("rpm.dependency-hardlink log4j-1.2.14.jar missing!")
+}
+
+return true

--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -654,6 +654,16 @@ abstract class AbstractRPMMojo
      */
     @Parameter(defaultValue = "false")
     private boolean skipPOMs;
+    
+    /**
+     * Indicates if the dependencies should be hard linked instead of copied.
+     * <br />
+     * <b>NOTE:</b> Hard link requires maven repository to be on same partition as project's build dir. 
+     * 
+     * @since TODO
+     */
+    @Parameter(defaultValue = "false")
+    private boolean hardLinkDependencies;
 
     //////////////////////////////////////////////////////////////////////////
 
@@ -1629,9 +1639,16 @@ abstract class AbstractRPMMojo
     }
 
     /**
+     * @return Returns the {@link #hardLinkDependencies}
+     */
+    final boolean isHardLinkDependencies() {
+        return hardLinkDependencies;
+    }
+    
+    /**
      * @return the rpmbuildStage
      */
-    final public String getRpmbuildStage()
+    final String getRpmbuildStage()
     {
         return rpmbuildStage;
     }
@@ -1639,11 +1656,12 @@ abstract class AbstractRPMMojo
     /**
      * @param rpmRpmbuildStage the rpmRpmbuildStage to set
      */
-    final public void setRpmbuildStage( String rpmbuildStage )
+    final void setRpmbuildStage( String rpmbuildStage )
     {
         this.rpmbuildStage = rpmbuildStage;
     }
 
+    
     /**
      * Load and decrypt gpg passphrase from maven settings if not given from plugin configuration
      *
@@ -1673,4 +1691,5 @@ abstract class AbstractRPMMojo
             }
         }
     }
+
 }


### PR DESCRIPTION
Instead of copying artifact to directory, hard link files.
This option cannot be used if local maven repository is in different partition.
Two benefits:
1) Requires less space to build
2) Faster because only link needs to be written
And cons:
1) Implementation requires Java 7 (nio)
2) Code is not backwards compatible (integration tests were broken by previous
regression, copied fix from #85)