### PR TITLE
Fixed targetOSName example

### DIFF
--- a/src/site/apt/source-params.apt
+++ b/src/site/apt/source-params.apt
@@ -185,12 +185,12 @@ Source Parameters
                ...
                 <sources>
                   <source>
-                    <location>src/main/native/x86_64</location>
-                    <targetArchitecture>x86_64</targetArchitecture>
+                    <location>src/main/native/linux</location>
+                    <targetOSName>Linux</targetOSName>
                   </source>
                   <source>
-                    <location>src/main/native/x86</location>
-                    <targetArchitecture>i.86</targetArchitecture>
+                    <location>src/main/native/osx</location>
+                    <targetOSName>.*OS X</targetOSName>
                   </source>
                 </sources>
                 ...


### PR DESCRIPTION
The source mapping xml tag "targetOSName" must be used in the example section (instead of "targetArchitecture").