### PR TITLE
Explicitly specify the os and dist to be used by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: java
 
+os: linux
+dist: trusty
+
 jdk:
   - openjdk7 #Travis does not support oraclejdk7 anymore
   - oraclejdk8


### PR DESCRIPTION
Roughly 5 months ago the default Travis CI image (when not explicitly specified) changed to Ubuntu Xenial (16.x), as the .travis.yml does not specify a dist builds are now executed on Xenial where the specified JDKs are not available. I expect that by specifying the intended OS/dist the build for PR #95 should run again.

Info on the move to Xenial
https://changelog.travis-ci.com/xenial-as-the-default-build-environment-99476
Was: ~https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment~
Now: http://web.archive.org/web/20230325151008/https://blog.travis-ci.com/2019-04-15-xenial-default-build-environment

Trusty JDK support:
https://docs.travis-ci.com/user/reference/trusty/#jvm-clojure-groovy-java-scala-images

Xenial JDK support:
https://docs.travis-ci.com/user/reference/xenial/#jvm-clojure-groovy-java-scala-support