### PR TITLE
feat: Added suggests field to spec file

### DIFF
--- a/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
+++ b/src/main/java/org/codehaus/mojo/rpm/AbstractRPMMojo.java
@@ -335,6 +335,12 @@ public abstract class AbstractRPMMojo
     private LinkedHashSet<String> conflicts;
 
     /**
+     * The list of suggested packages for this package.
+     */
+    @Parameter
+    private LinkedHashSet<String> suggests;
+
+    /**
      * The relocation prefix for this package.
      *
      */
@@ -1383,6 +1389,14 @@ public abstract class AbstractRPMMojo
     final LinkedHashSet<String> getConflicts()
     {
         return this.conflicts;
+    }
+
+    /**
+     * @return Returns the {@link #suggests}.
+     */
+    final LinkedHashSet<String> getSuggests()
+    {
+        return this.suggests;
     }
 
     final List<String> getPrefixes()

--- a/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
+++ b/src/main/java/org/codehaus/mojo/rpm/SpecWriter.java
@@ -98,6 +98,7 @@ final class SpecWriter
         writeList( mojo.getPrereqs(), "PreReq: " );
         writeList( mojo.getObsoletes(), "Obsoletes: " );
         writeList( mojo.getConflicts(), "Conflicts: " );
+        writeList( mojo.getSuggests(), "Suggests: " );
 
         spec.println( "autoprov: " + ( mojo.isAutoProvides() ? "yes" : "no" ) );
         spec.println( "autoreq: " + ( mojo.isAutoRequires() ? "yes" : "no" ) );
@@ -295,7 +296,8 @@ final class SpecWriter
         }
     }
 
-    private String assembleBaseString(String destination, String dirAttrString) {
+    private String assembleBaseString( String destination, String dirAttrString )
+    {
         return dirAttrString + "  \"" + destination + FileHelper.UNIX_FILE_SEPARATOR;
     }
 

--- a/src/site/apt/adv-params.apt
+++ b/src/site/apt/adv-params.apt
@@ -18,7 +18,7 @@ Advanced Parameters
   <<These parameters relate to the dependencies between RPM packages, not to
   the dependencies required to build the RPM package contents.>>
 
-  There are six RPM spec file tags related to dependency management:
+  There are several RPM spec file tags related to dependency management:
 
     * <<<provides>>> defines a <virtual package> which is provided
       by the package being built
@@ -44,6 +44,10 @@ Advanced Parameters
 
     * <<<conflicts>>> identifies a package which must not be installed if the
       package being built is installed
+
+    * <<<suggests>>> identifies a package which is suggested as an optional dependency
+      and is not required to be installed for the package being built to operate correctly.
+      Corresponds to the <<<Suggests>>> tag in the spec file.
 
   All of these tags can appear multiple times in the spec file.  To
   configure these tags in the plugin configuration, specify an element for
@@ -74,6 +78,9 @@ Advanced Parameters
 <conflicts>
   <conflict>incinerator</conflict>
 </conflicts>
+<suggests>
+  <suggest>optional-tool &gt; 2.0</suggest>
+</suggests>
 +-----+
 
 * RPM Build Dependency Management


### PR DESCRIPTION
This PR adds the possibility to set the `Suggests` field in the spec file. The syntax is the same as the `Requires`parameter:

```xml
<suggests>
    <suggest>additional_dependency</suggest>
</suggests>
```